### PR TITLE
Fix remove timezone for date

### DIFF
--- a/lib/administrate/field/date.rb
+++ b/lib/administrate/field/date.rb
@@ -5,7 +5,7 @@ module Administrate
     class Date < Base
       def date
         I18n.localize(
-          data.in_time_zone(timezone).to_date,
+          data.to_date,
           format: format,
         )
       end


### PR DESCRIPTION
Remove the `timezone` usage inside the new Date field.