### PR TITLE
Include Date Field

### DIFF
--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -7,4 +7,8 @@ $(function () {
     debug: false,
     format: "YYYY-MM-DD HH:mm:ss",
   });
+  $('[data-type="date"]').datetimepicker({
+    debug: false,
+    format: "YYYY-MM-DD",
+  });
 });

--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,14 +1,14 @@
 $(function () {
   $('[data-type="time"]').datetimepicker({
     debug: false,
-    format: "HH:mm:ss",
+    format: 'HH:mm:ss',
   });
   $('[data-type="datetime"]').datetimepicker({
     debug: false,
-    format: "YYYY-MM-DD HH:mm:ss",
+    format: 'YYYY-MM-DD HH:mm:ss',
   });
   $('[data-type="date"]').datetimepicker({
     debug: false,
-    format: "YYYY-MM-DD",
+    format: 'YYYY-MM-DD',
   });
 });

--- a/app/views/fields/date/_form.html.erb
+++ b/app/views/fields/date/_form.html.erb
@@ -1,0 +1,24 @@
+<%#
+# Date Form Partial
+
+This partial renders an input element for a date attribute.
+By default, the input is a text field that is augmented with [DateTimePicker].
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Date][1].
+  A wrapper around the Date value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Date
+[DateTimePicker]: https://github.com/Eonasdan/bootstrap-datetimepicker
+%>
+
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.text_field field.attribute, data: { type: 'date' }  %>
+</div>

--- a/app/views/fields/date/_index.html.erb
+++ b/app/views/fields/date/_index.html.erb
@@ -1,0 +1,21 @@
+<%#
+# Date Index Partial
+
+This partial renders a date attribute,
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered
+as a localized date string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Date][1].
+  A wrapper around the Date value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Date
+%>
+
+<% if field.data %>
+  <%= field.date %>
+<% end %>

--- a/app/views/fields/date/_show.html.erb
+++ b/app/views/fields/date/_show.html.erb
@@ -1,0 +1,21 @@
+<%#
+# Date Show Partial
+
+This partial renders a date attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered
+as a localized date string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Date][1].
+  A wrapper around the Date value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Date
+%>
+
+<% if field.data %>
+  <%= field.date %>
+<% end %>

--- a/docs/customizing_attribute_partials.md
+++ b/docs/customizing_attribute_partials.md
@@ -6,6 +6,7 @@ across all dashboards. You can customize the following built in field types:
 - `belongs_to`
 - `boolean`
 - `date_time`
+- `date`
 - `email`
 - `has_many`
 - `has_one`

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -190,6 +190,11 @@ objects to display as.
 `:timezone` - Specify which timezone `Date` and `DateTime` objects are based
 in.
 
+**Field::Date**
+
+`:format` - Specify what format, using `strftime` you would like `Date`
+objects to display as.
+
 **Field::Select**
 
 `:collection` - Specify the array or range to select from. Defaults to `[]`.

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -1,6 +1,7 @@
 require "administrate/field/belongs_to"
 require "administrate/field/boolean"
 require "administrate/field/date_time"
+require "administrate/field/date"
 require "administrate/field/email"
 require "administrate/field/has_many"
 require "administrate/field/has_one"

--- a/lib/administrate/field/date.rb
+++ b/lib/administrate/field/date.rb
@@ -1,0 +1,20 @@
+require_relative "base"
+
+module Administrate
+  module Field
+    class Date < Base
+      def date
+        I18n.localize(
+          data.to_date,
+          format: format,
+        )
+      end
+
+      private
+
+      def format
+        options.fetch(:format, :default)
+      end
+    end
+  end
+end

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -5,7 +5,7 @@ module Administrate
     class DashboardGenerator < Rails::Generators::NamedBase
       ATTRIBUTE_TYPE_MAPPING = {
         boolean: "Field::Boolean",
-        date: "Field::DateTime",
+        date: "Field::Date",
         datetime: "Field::DateTime",
         enum: "Field::String",
         float: "Field::Number",

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -174,8 +174,8 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         end
       end
 
-      it "assigns dates, times, and datetimes a type of `DateTime` and
-          `Time`" do
+      it "assigns dates, times, and datetimes a type of `Date`, `DateTime` and
+      `Time` respectively" do
         begin
           ActiveRecord::Schema.define do
             create_table :events do |t|
@@ -193,7 +193,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           load file("app/dashboards/event_dashboard.rb")
           attrs = EventDashboard::ATTRIBUTE_TYPES
 
-          expect(attrs[:start_date]).to eq(Administrate::Field::DateTime)
+          expect(attrs[:start_date]).to eq(Administrate::Field::Date)
           expect(attrs[:start_time]).to eq(Administrate::Field::Time)
           expect(attrs[:ends_at]).to eq(Administrate::Field::DateTime)
         ensure

--- a/spec/lib/fields/date_spec.rb
+++ b/spec/lib/fields/date_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require "administrate/field/date"
+
+describe Administrate::Field::Date do
+  let(:start_date) { Date.parse("2015-12-25") }
+  let(:formats) do
+    {
+      date: {
+        formats: { default: "%m/%d/%Y", short: "%b %d" },
+        abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
+        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 },
+      },
+      time: {
+        formats: { default: "%a, %b %-d, %Y", short: "%d %b" },
+      },
+    }
+  end
+
+  describe "#date" do
+    it "displays the date" do
+      with_translations(:en, formats) do
+        field = Administrate::Field::Date.
+          new(:start_date, start_date, :show)
+        expect(field.date).to eq("12/25/2015")
+      end
+    end
+
+    context "with `prefix` option" do
+      it "displays the date in the requested format" do
+        options_field = Administrate::Field::Date.
+          with_options(format: :short)
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.date).to eq("Dec 25")
+        end
+      end
+
+      it "displays the date using a format string" do
+        options_field = Administrate::Field::Date.
+          with_options(format: "%Y")
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.date).to eq("2015")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a Date Field, where the datepicker lets the admin user select just a date without time.

![Screen Shot 2020-01-16 at 12 49 51 PM](https://user-images.githubusercontent.com/20058206/72539880-c5830200-385e-11ea-922a-58f1d8038373.png)

**Notes:**
- After needing a Date field on the project I'm working, and seeing there were other people that reported their desire to have it (see https://github.com/thoughtbot/administrate/issues/741), I decided to contribute to Administrate with this PR 😃 
